### PR TITLE
Addition of mqtt config file and mqtt ingress for debugging

### DIFF
--- a/config.env
+++ b/config.env
@@ -2,6 +2,7 @@
 NODE_ENV=devl
 LOG_LEVEL=info
 # MQTT_URI=mqtt://mqtt
-MQTT_URI=mqtt://fitlet2-1:31830
+# MQTT_URI=mqtt://fitlet2-1:31830
 HOSTNAME=localhost
 VERSION=v1
+

--- a/k8s/config/mosquitto.conf
+++ b/k8s/config/mosquitto.conf
@@ -1,0 +1,2 @@
+listener 1883
+allow_anonymous true

--- a/k8s/mqtt-deployment.yaml
+++ b/k8s/mqtt-deployment.yaml
@@ -19,4 +19,10 @@ spec:
         image: eclipse-mosquitto 
         ports:
         - containerPort: 1883
-
+        volumeMounts:
+          - name: config
+            mountPath: /mosquitto/config/
+      volumes:
+      - name: config
+        configMap:
+          name: mqtt-cfg

--- a/k8s/mqtt-ingress.yaml
+++ b/k8s/mqtt-ingress.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: mqtt-ingress
+spec:
+  backend:
+    serviceName: mqtt
+    servicePort: 1883


### PR DESCRIPTION
Primary addition is the `mqtt` config as new versions of `mqtt` do not allow anon access by default. Also commented out (unused?) hardcoded hostname in config to ensure it is not used and added ingress config for testing mqtt